### PR TITLE
Update lib_statistics.f90

### DIFF
--- a/src/lib_statistics.f90
+++ b/src/lib_statistics.f90
@@ -78,7 +78,7 @@ contains
     real(dp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
     if(present(mask)) then
-       mean_dp = sum(x, mask=mask)/size(x)
+       mean_dp = sum(x, mask=mask)/count(mask)
     else
        mean_dp = sum(x)/size(x)
     end if
@@ -129,7 +129,11 @@ contains
     implicit none
     real(dp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
-    variance_dp = sum(x-mean(x, mask=mask)**2._dp)/(size(x)-1)
+    if(present(mask)) then
+      variance_dp = sum((x-mean(x, mask=mask))**2._dp, mask=mask)/(count(mask)-1)
+    else
+      variance_dp = sum((x-mean(x))**2._dp)/(size(x)-1)
+    end if
   end function variance_dp
 
   real(dp) function clipped_mean_dp(x, n)
@@ -156,7 +160,7 @@ contains
     real(sp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
     if(present(mask)) then
-       mean_sp = sum(x, mask=mask)/size(x)
+       mean_sp = sum(x, mask=mask)/count(mask)
     else
        mean_sp = sum(x)/size(x)
     end if
@@ -207,7 +211,11 @@ contains
     implicit none
     real(sp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
-    variance_sp = sum(x-mean(x, mask=mask)**2._sp)/(size(x)-1)
+    if(present(mask)) then
+      variance_sp = sum((x-mean(x, mask=mask))**2._sp, mask=mask)/(count(mask)-1)
+    else
+      variance_sp = sum((x-mean(x))**2._sp)/(size(x)-1)
+    end if
   end function variance_sp
 
   real(sp) function clipped_mean_sp(x, n)


### PR DESCRIPTION
1. function mean: When mask'ed, divide by `count(mask)` instead of `size(x)`
2. function variance: When mask'ed, divide by `count(mask)` instead of `size(x)`. Also a bug: `variance = sum((x-mean(x))**2)`, was `sum(x-mean(x)**2)`.
