### PR TITLE
A few correctness fixes

### DIFF
--- a/src/lib_array.f90
+++ b/src/lib_array.f90
@@ -1,4 +1,4 @@
-! MD5 of template: 13982be359376d65d4f966553ef27636
+! MD5 of template: 4f5c6d3840bf88952e83ee29dfbbb6fc
 ! Array related routines (Integration, Interpolation, etc.)
 !
 ! ------------------------------------------------------------------------------
@@ -454,7 +454,7 @@ contains
 
     real(dp),intent(in) :: x(:),y(:),x1,x2
     integer :: i1,i2
-    real(dp) :: f1,f2
+    real(dp) :: f1,f2,xx1,xx2
     integer :: n
 
     interface
@@ -483,17 +483,25 @@ contains
     if(x1.gt.x(1)) then
        i1 = locate(x,x1)
        f1 = f_interp(x,y,x1)
+       xx1 = x1
     else
+       ! Clamp the lower limit to the tabulated range so that no
+       ! spurious area is added outside the domain
        i1 = 0
-       f1 = 0._dp
+       f1 = y(1)
+       xx1 = x(1)
     end if
 
     if(x2.lt.x(n)) then
        i2 = locate(x,x2)
        f2 = f_interp(x,y,x2)
+       xx2 = x2
     else
+       ! Clamp the upper limit to the tabulated range so that no
+       ! spurious area is added outside the domain
        i2 = n
-       f2 = 0._dp
+       f2 = y(n)
+       xx2 = x(n)
     end if
 
     if(i2.gt.i1) then
@@ -506,12 +514,12 @@ contains
        end if
 
        ! Add extremities
-       sum = sum + f_chunk(x1,f1,x(i1+1),y(i1+1))
-       sum = sum + f_chunk(x(i2),y(i2),x2,f2)
+       sum = sum + f_chunk(xx1,f1,x(i1+1),y(i1+1))
+       sum = sum + f_chunk(x(i2),y(i2),xx2,f2)
 
     else
 
-       sum = f_chunk(x1,f1,x2,f2)
+       sum = f_chunk(xx1,f1,xx2,f2)
 
     end if
 
@@ -1460,7 +1468,7 @@ contains
 
     real(sp),intent(in) :: x(:),y(:),x1,x2
     integer :: i1,i2
-    real(sp) :: f1,f2
+    real(sp) :: f1,f2,xx1,xx2
     integer :: n
 
     interface
@@ -1489,17 +1497,25 @@ contains
     if(x1.gt.x(1)) then
        i1 = locate(x,x1)
        f1 = f_interp(x,y,x1)
+       xx1 = x1
     else
+       ! Clamp the lower limit to the tabulated range so that no
+       ! spurious area is added outside the domain
        i1 = 0
-       f1 = 0._sp
+       f1 = y(1)
+       xx1 = x(1)
     end if
 
     if(x2.lt.x(n)) then
        i2 = locate(x,x2)
        f2 = f_interp(x,y,x2)
+       xx2 = x2
     else
+       ! Clamp the upper limit to the tabulated range so that no
+       ! spurious area is added outside the domain
        i2 = n
-       f2 = 0._sp
+       f2 = y(n)
+       xx2 = x(n)
     end if
 
     if(i2.gt.i1) then
@@ -1512,12 +1528,12 @@ contains
        end if
 
        ! Add extremities
-       sum = sum + f_chunk(x1,f1,x(i1+1),y(i1+1))
-       sum = sum + f_chunk(x(i2),y(i2),x2,f2)
+       sum = sum + f_chunk(xx1,f1,x(i1+1),y(i1+1))
+       sum = sum + f_chunk(x(i2),y(i2),xx2,f2)
 
     else
 
-       sum = f_chunk(x1,f1,x2,f2)
+       sum = f_chunk(xx1,f1,xx2,f2)
 
     end if
 

--- a/src/lib_array.f90
+++ b/src/lib_array.f90
@@ -1,4 +1,4 @@
-! MD5 of template: 4f5c6d3840bf88952e83ee29dfbbb6fc
+! MD5 of template: 7bd053d641d62ff583cf30cacc7bae36
 ! Array related routines (Integration, Interpolation, etc.)
 !
 ! ------------------------------------------------------------------------------
@@ -982,14 +982,14 @@ contains
 
     else
 
-       if(x < xmax) then
+       if(x > xmin) then
           ipos_dp = 0
-       else if(x > xmin) then
+       else if(x < xmax) then
           ipos_dp = nbin+1
-       else if(x < xmin) then
+       else if(x > xmax) then
           frac=(x-xmin)/(xmax-xmin)
           ipos_dp=int(frac*real(nbin, dp))+1
-       else  ! x == xmin
+       else  ! x == xmax
           ipos_dp = nbin
        end if
 
@@ -1996,14 +1996,14 @@ contains
 
     else
 
-       if(x < xmax) then
+       if(x > xmin) then
           ipos_sp = 0
-       else if(x > xmin) then
+       else if(x < xmax) then
           ipos_sp = nbin+1
-       else if(x < xmin) then
+       else if(x > xmax) then
           frac=(x-xmin)/(xmax-xmin)
           ipos_sp=int(frac*real(nbin, sp))+1
-       else  ! x == xmin
+       else  ! x == xmax
           ipos_sp = nbin
        end if
 

--- a/src/lib_array.f90
+++ b/src/lib_array.f90
@@ -1,4 +1,4 @@
-! MD5 of template: 7bd053d641d62ff583cf30cacc7bae36
+! MD5 of template: a4d2f189e6a05079680e0b18e875b696
 ! Array related routines (Integration, Interpolation, etc.)
 !
 ! ------------------------------------------------------------------------------
@@ -1014,7 +1014,7 @@ contains
 
     real(dp) :: frac
 
-    frac=(real(i-1)+0.5)/real(nbin)
+    frac=(real(i-1,dp)+0.5_dp)/real(nbin,dp)
 
     xval_dp=frac*(xmax-xmin)+xmin
 
@@ -2028,7 +2028,7 @@ contains
 
     real(sp) :: frac
 
-    frac=(real(i-1)+0.5)/real(nbin)
+    frac=(real(i-1,sp)+0.5_sp)/real(nbin,sp)
 
     xval_sp=frac*(xmax-xmin)+xmin
 

--- a/src/lib_statistics.f90
+++ b/src/lib_statistics.f90
@@ -1,4 +1,4 @@
-! MD5 of template: de2e124b77d41b637ba47e23b573548c
+! MD5 of template: 735c35cef984eefb2cbe85fa23cb26bb
 ! Statistics
 !
 ! ------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ contains
     implicit none
     real(dp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
-    variance_dp = sum(x-mean(x, mask=mask)**2._dp)/(size(x)-1)
+    variance_dp = sum((x-mean(x, mask=mask))**2._dp)/(size(x)-1)
   end function variance_dp
 
   real(dp) function clipped_mean_dp(x, n)
@@ -207,7 +207,7 @@ contains
     implicit none
     real(sp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
-    variance_sp = sum(x-mean(x, mask=mask)**2._sp)/(size(x)-1)
+    variance_sp = sum((x-mean(x, mask=mask))**2._sp)/(size(x)-1)
   end function variance_sp
 
   real(sp) function clipped_mean_sp(x, n)

--- a/src/lib_statistics.f90
+++ b/src/lib_statistics.f90
@@ -1,4 +1,4 @@
-! MD5 of template: 735c35cef984eefb2cbe85fa23cb26bb
+! MD5 of template: ed65b7e8a488cb6260b99427178b6e9f
 ! Statistics
 !
 ! ------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ contains
     real(dp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
     if(present(mask)) then
-       mean_dp = sum(x, mask=mask)/size(x)
+       mean_dp = sum(x, mask=mask)/count(mask)
     else
        mean_dp = sum(x)/size(x)
     end if
@@ -156,7 +156,7 @@ contains
     real(sp),intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
     if(present(mask)) then
-       mean_sp = sum(x, mask=mask)/size(x)
+       mean_sp = sum(x, mask=mask)/count(mask)
     else
        mean_sp = sum(x)/size(x)
     end if

--- a/src/type_pdf.f90
+++ b/src/type_pdf.f90
@@ -1,4 +1,4 @@
-! MD5 of template: e8ce72b1fbc6a396e11ba55e6dc29db9
+! MD5 of template: 38970a5d63fbd6c0c61fdf600f0968f9
 ! Probability Distribution Function (PDF) related routines
 !
 ! ------------------------------------------------------------------------------
@@ -390,7 +390,13 @@ contains
     else
        call random(xi)
     end if
-    sample_pdf_cont_log_dp = interp1d_loglog(p%cdf(:),p%x(:),xi)
+    if(xi <= p%cdf(1)) then
+       sample_pdf_cont_log_dp = p%x(1)
+    else if(xi >= p%cdf(p%n)) then
+       sample_pdf_cont_log_dp = p%x(p%n)
+    else
+       sample_pdf_cont_log_dp = interp1d_linlog(p%cdf(:),p%x(:),xi)
+    end if
   end function sample_pdf_cont_log_dp
 
   real(dp) function interpolate_pdf_cont_dp(p, x, bounds_error, fill_value) result(prob)
@@ -634,7 +640,13 @@ contains
     else
        call random(xi)
     end if
-    sample_pdf_cont_log_sp = interp1d_loglog(p%cdf(:),p%x(:),xi)
+    if(xi <= p%cdf(1)) then
+       sample_pdf_cont_log_sp = p%x(1)
+    else if(xi >= p%cdf(p%n)) then
+       sample_pdf_cont_log_sp = p%x(p%n)
+    else
+       sample_pdf_cont_log_sp = interp1d_linlog(p%cdf(:),p%x(:),xi)
+    end if
   end function sample_pdf_cont_log_sp
 
   real(sp) function interpolate_pdf_cont_sp(p, x, bounds_error, fill_value) result(prob)

--- a/templates/lib_array_template.f90
+++ b/templates/lib_array_template.f90
@@ -435,7 +435,7 @@ contains
 
     real(<T>),intent(in) :: x(:),y(:),x1,x2
     integer :: i1,i2
-    real(<T>) :: f1,f2
+    real(<T>) :: f1,f2,xx1,xx2
     integer :: n
 
     interface
@@ -464,17 +464,25 @@ contains
     if(x1.gt.x(1)) then
        i1 = locate(x,x1)
        f1 = f_interp(x,y,x1)
+       xx1 = x1
     else
+       ! Clamp the lower limit to the tabulated range so that no
+       ! spurious area is added outside the domain
        i1 = 0
-       f1 = 0._<T>
+       f1 = y(1)
+       xx1 = x(1)
     end if
 
     if(x2.lt.x(n)) then
        i2 = locate(x,x2)
        f2 = f_interp(x,y,x2)
+       xx2 = x2
     else
+       ! Clamp the upper limit to the tabulated range so that no
+       ! spurious area is added outside the domain
        i2 = n
-       f2 = 0._<T>
+       f2 = y(n)
+       xx2 = x(n)
     end if
 
     if(i2.gt.i1) then
@@ -487,12 +495,12 @@ contains
        end if
 
        ! Add extremities
-       sum = sum + f_chunk(x1,f1,x(i1+1),y(i1+1))
-       sum = sum + f_chunk(x(i2),y(i2),x2,f2)
+       sum = sum + f_chunk(xx1,f1,x(i1+1),y(i1+1))
+       sum = sum + f_chunk(x(i2),y(i2),xx2,f2)
 
     else
 
-       sum = f_chunk(x1,f1,x2,f2)
+       sum = f_chunk(xx1,f1,xx2,f2)
 
     end if
 

--- a/templates/lib_array_template.f90
+++ b/templates/lib_array_template.f90
@@ -963,14 +963,14 @@ contains
 
     else
 
-       if(x < xmax) then
+       if(x > xmin) then
           ipos_<T> = 0
-       else if(x > xmin) then
+       else if(x < xmax) then
           ipos_<T> = nbin+1
-       else if(x < xmin) then
+       else if(x > xmax) then
           frac=(x-xmin)/(xmax-xmin)
           ipos_<T>=int(frac*real(nbin, <T>))+1
-       else  ! x == xmin
+       else  ! x == xmax
           ipos_<T> = nbin
        end if
 

--- a/templates/lib_array_template.f90
+++ b/templates/lib_array_template.f90
@@ -995,7 +995,7 @@ contains
 
     real(<T>) :: frac
 
-    frac=(real(i-1)+0.5)/real(nbin)
+    frac=(real(i-1,<T>)+0.5_<T>)/real(nbin,<T>)
 
     xval_<T>=frac*(xmax-xmin)+xmin
 

--- a/templates/lib_statistics_template.f90
+++ b/templates/lib_statistics_template.f90
@@ -78,7 +78,7 @@ contains
     @T,intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
     if(present(mask)) then
-       mean_<T> = sum(x, mask=mask)/size(x)
+       mean_<T> = sum(x, mask=mask)/count(mask)
     else
        mean_<T> = sum(x)/size(x)
     end if

--- a/templates/lib_statistics_template.f90
+++ b/templates/lib_statistics_template.f90
@@ -129,7 +129,7 @@ contains
     implicit none
     @T,intent(in) :: x(:)
     logical,intent(in),optional :: mask(:)
-    variance_<T> = sum(x-mean(x, mask=mask)**2._<T>)/(size(x)-1)
+    variance_<T> = sum((x-mean(x, mask=mask))**2._<T>)/(size(x)-1)
   end function variance_<T>
 
   @T function clipped_mean_<T>(x, n)

--- a/templates/type_pdf_template.f90
+++ b/templates/type_pdf_template.f90
@@ -363,7 +363,13 @@ contains
     else
        call random(xi)
     end if
-    sample_pdf_cont_log_<T> = interp1d_loglog(p%cdf(:),p%x(:),xi)
+    if(xi <= p%cdf(1)) then
+       sample_pdf_cont_log_<T> = p%x(1)
+    else if(xi >= p%cdf(p%n)) then
+       sample_pdf_cont_log_<T> = p%x(p%n)
+    else
+       sample_pdf_cont_log_<T> = interp1d_linlog(p%cdf(:),p%x(:),xi)
+    end if
   end function sample_pdf_cont_log_<T>
 
   @T function interpolate_pdf_cont_<T>(p, x, bounds_error, fill_value) result(prob)


### PR DESCRIPTION
This fixes a few bugs:

  - **`integral_general_subset` adds spurious area outside the tabulated range.** When the integration limits extend beyond the tabulated `x`, the routine adds a triangular ramp of area past the domain  instead of clamping. Fix: clamp the effective limits to `[x(1), x(n)]` so out-of-range extremities contribute zero.

  - **`ipos` mishandles both boundaries for descending ranges (`xmax < xmin`).** `x == xmin` and `x == xmax` return off-by-one bins. Fix: correct the boundary handling so `xmin` maps to bin 1 and   `xmax` to bin `nbin`.

  - **`xval` computes bin centres in single precision.** The bin-centre fraction `(i - 0.5) / nbin` is evaluated in default (single) precision before being used, so the double-precision instantiation   loses precision. Fix: compute the fraction in the instantiated kind.
  
  - **`sample_pdf_log` returns NaN for draws in the first CDF bin.** A random value landing in the first bin feeds `cdf(1) = 0` into log-log interpolation (`log(0)`), producing NaN. Fix: use linear  interpolation on the CDF axis with boundary guards.